### PR TITLE
Update collection with basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Smooch Public Postman Collection
+
 This repo is a placeholder to the Smooch API Postman Collection.
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/e65de26d697c48836f1e#?env%5BSmooch%20Public%20Env%5D=W3sia2V5IjoidXJsIiwidmFsdWUiOiJodHRwczovL2FwaS5zbW9vY2guaW8iLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFwaVZlcnNpb24iLCJ2YWx1ZSI6IiIsImRlc2NyaXB0aW9uIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJhcHBJZCIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJhcHBVc2VySWQiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9LHsia2V5IjoiSldUIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFwcEtleUlkIiwidmFsdWUiOiIiLCJkZXNjcmlwdGlvbiI6IiIsImVuYWJsZWQiOnRydWV9LHsia2V5IjoiaW50ZWdyYXRpb25JZCIsInZhbHVlIjoiIiwiZGVzY3JpcHRpb24iOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6InNlcnZpY2VBY2NvdW50SWQiLCJ2YWx1ZSI6IiIsImRlc2NyaXB0aW9uIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJzZXJ2aWNlS2V5SWQiLCJ2YWx1ZSI6IiIsImRlc2NyaXB0aW9uIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJ0ZW1wbGF0ZUlkIiwidmFsdWUiOiIiLCJkZXNjcmlwdGlvbiI6IiIsImVuYWJsZWQiOnRydWV9LHsia2V5Ijoid2ViaG9va0lkIiwidmFsdWUiOiIiLCJkZXNjcmlwdGlvbiI6IiIsImVuYWJsZWQiOnRydWV9XQ==)
@@ -7,14 +8,13 @@ This repo is a placeholder to the Smooch API Postman Collection.
 
 Please follow [this guide](https://docs.smooch.io/guide/postman-collection/) to set up your Postman environment
 
-
 ## Environment Variables
-| key  | value | Comments |
-| :--- | ----- | -------- |
-| **url**    | https://api.smooch.io | |
-| **appId**  | _id of the app used to send/receive data_ | It can be found in the settings tab your app. |
-| **apiVersion**  | _The API version to use. See [API versioning](https://docs.smooch.io/guide/versioning/#api) to learn more._ | |
-| **appUserId** | _the user used to send/receive messages_ | This can also be set in the API call params. |
-| **JWT**    | _JWT Token_ | See this [guide](https://docs.smooch.io/guide/jwt/#json-web-tokens-jwts) for more information. |
 
-There are many other ways of getting a `JWT` depending on your environment. We provide a few examples in our [guide docs](https://docs.smooch.io/guide/jwt/#json-web-tokens-jwts).
+| key            | value                                                                                                       | Comments                                                                                               |
+| :------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **url**        | https://api.smooch.io                                                                                       |                                                                                                        |
+| **appId**      | _id of the app used to send/receive data_                                                                   | It can be found in the settings tab your app.                                                          |
+| **apiVersion** | _The API version to use. See [API versioning](https://docs.smooch.io/guide/versioning/#api) to learn more._ |                                                                                                        |
+| **appUserId**  | _the user used to send/receive messages_                                                                    | This can also be set in the API call params.                                                           |
+| **keyId**      | _Key ID_                                                                                                    | See this [guide](https://docs.smooch.io/guide/authentication-overview/#api-keys) for more information. |
+| **secret**     | _Secret_                                                                                                    | See this [guide](https://docs.smooch.io/guide/authentication-overview/#api-keys) for more information. |

--- a/Smooch.postman_collection.json
+++ b/Smooch.postman_collection.json
@@ -18258,11 +18258,16 @@
 		}
 	],
 	"auth": {
-		"type": "bearer",
-		"bearer": [
+		"type": "basic",
+		"basic": [
 			{
-				"key": "token",
-				"value": "{{JWT}}",
+				"key": "password",
+				"value": "{{secret}}",
+				"type": "string"
+			},
+			{
+				"key": "username",
+				"value": "{{keyId}}",
 				"type": "string"
 			}
 		]


### PR DESCRIPTION
We are adding basic authentication support to the API, which means we don't need to generate JWTs in order to use Postman 🎉 We can just use API keys (previously known as secret keys) directly 😄 

This PR updates the collection to support basic authentication.

I'll update the Postman instructions in the guide in https://github.com/smooch/smooch-docs/pull/852

Implementation: https://github.com/smooch/smooch/pull/6226