### PR TITLE
Fix Link App User To Channel payload

### DIFF
--- a/Smooch.postman_collection.json
+++ b/Smooch.postman_collection.json
@@ -2087,7 +2087,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"type\": \"mailgun\",\n\t\"confirmation\": {\n\t\t\"type\": \"prompt\"\n\t},\n\t\"address\": \"their@email.com\"\n}",
+									"raw": "{\n\t\"type\": \"mailgun\",\n\t\"confirmation\": {\n\t\t\"type\": \"immediate\"\n\t},\n\t\"address\": \"their@email.com\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/Smooch.postman_collection.json
+++ b/Smooch.postman_collection.json
@@ -2085,7 +2085,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"type\": \"twilio\",\n\t\"confirmation\": {\n\t\t\"type\": \"prompt\",\n\t\t\"phoneNumber\": \"+15145555555\"\n\t}\n}"
+									"raw": "{\n\t\"type\": \"mailgun\",\n\t\"confirmation\": {\n\t\t\"type\": \"prompt\"\n\t},\n\t\"address\": \"their@email.com\"\n}"
 								},
 								"url": {
 									"raw": "{{url}}/v1/apps/:appId/appusers/:userId/channels",
@@ -2112,8 +2112,8 @@
 									]
 								}
 							},
-							"status": "Not Found",
-							"code": 404,
+							"status": "OK",
+							"code": 200,
 							"_postman_previewlanguage": "json",
 							"header": [
 								{
@@ -2178,7 +2178,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"appUser\": {\n        \"_id\": \"deb920657bbc3adc3fec7963\",\n        \"userId\": \"steveb@channel5.com\",\n        \"givenName\": \"Steve\",\n        \"signedUpAt\": \"2015-10-08T23:52:11.677Z\",\n        \"properties\": {\n          \"favoriteFood\": \"pizza\"\n        },\n        \"conversationStarted\": false,\n        \"credentialRequired\": false,\n        \"clients\": [],\n        \"pendingClients\": [\n            {\n                \"id\": \"d383f9f4-c8d2-42dd-9f7c-f525fad6849d\",\n                \"platform\": \"twilio\",\n                \"displayName\": \"+15145555555\"\n            }\n        ]\n    }\n}"
+							"body": "{\n    \"appUser\": {\n        \"_id\": \"deb920657bbc3adc3fec7963\",\n        \"userId\": \"c7f6e6d6c3a637261bd9656f\",\n        \"givenName\": \"Steve\",\n        \"signedUpAt\": \"2015-10-08T23:52:11.677Z\",\n        \"properties\": {\n          \"favoriteFood\": \"pizza\"\n        },\n        \"conversationStarted\": false,\n        \"credentialRequired\": false,\n        \"clients\": [],\n        \"pendingClients\": [\n            {\n                \"id\": \"d383f9f4-c8d2-42dd-9f7c-f525fad6849d\",\n                \"platform\": \"mailgun\",\n                \"displayName\": \"their@email.com\"\n            }\n        ]\n    }\n}"
 						}
 					]
 				},

--- a/Smooch.postman_collection.json
+++ b/Smooch.postman_collection.json
@@ -2054,7 +2054,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"type\": \"twilio\",\n\t\"confirmation\": {\n\t\t\"type\": \"prompt\",\n\t\t\"phoneNumber\": \"+15145555555\"\n\t}\n}"
+							"raw": "{\n\t\"type\": \"mailgun\",\n\t\"confirmation\": {\n\t\t\"type\": \"immediate\"\n\t},\n\t\"address\": \"their@email.com\"\n}"
 						},
 						"url": {
 							"raw": "{{url}}/{{apiVersion}}/apps/{{appId}}/appusers/{{appUserId}}/channels",

--- a/Smooch.postman_collection.json
+++ b/Smooch.postman_collection.json
@@ -2080,12 +2080,19 @@
 								"header": [
 									{
 										"key": "Content-Type",
-										"value": "application/json"
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"type\": \"mailgun\",\n\t\"confirmation\": {\n\t\t\"type\": \"prompt\"\n\t},\n\t\"address\": \"their@email.com\"\n}"
+									"raw": "{\n\t\"type\": \"mailgun\",\n\t\"confirmation\": {\n\t\t\"type\": \"prompt\"\n\t},\n\t\"address\": \"their@email.com\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
 								},
 								"url": {
 									"raw": "{{url}}/v1/apps/:appId/appusers/:userId/channels",

--- a/Smooch.postman_collection.json
+++ b/Smooch.postman_collection.json
@@ -2178,7 +2178,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"appUser\": {\n        \"_id\": \"deb920657bbc3adc3fec7963\",\n        \"userId\": \"c7f6e6d6c3a637261bd9656f\",\n        \"givenName\": \"Steve\",\n        \"signedUpAt\": \"2015-10-08T23:52:11.677Z\",\n        \"properties\": {\n          \"favoriteFood\": \"pizza\"\n        },\n        \"conversationStarted\": false,\n        \"credentialRequired\": false,\n        \"clients\": [],\n        \"pendingClients\": [\n            {\n                \"id\": \"d383f9f4-c8d2-42dd-9f7c-f525fad6849d\",\n                \"platform\": \"mailgun\",\n                \"displayName\": \"their@email.com\"\n            }\n        ]\n    }\n}"
+							"body": "{\n    \"appUser\": {\n        \"_id\": \"deb920657bbc3adc3fec7963\",\n        \"userId\": \"+5145555555\",\n        \"givenName\": \"Steve\",\n        \"signedUpAt\": \"2015-10-08T23:52:11.677Z\",\n        \"properties\": {\n          \"favoriteFood\": \"pizza\"\n        },\n        \"conversationStarted\": false,\n        \"credentialRequired\": false,\n        \"clients\": [],\n        \"pendingClients\": [\n            {\n                \"id\": \"d383f9f4-c8d2-42dd-9f7c-f525fad6849d\",\n                \"platform\": \"mailgun\",\n                \"displayName\": \"their@email.com\"\n            }\n        ]\n    }\n}"
 						}
 					]
 				},


### PR DESCRIPTION
## Request for Change

[[Postman] Bad request payload format for `Link User to Channel` example](https://zendesk.atlassian.net/browse/SCBE-552)

Modified the payload to use `type: mailgun` instead, and ensured the `address` was at the root-level.

Priority : `low` <!-- low/medium/high/urgent -->
Impact : `low` <!-- low/medium/high -->
Risk : `low` <!-- low/medium/high -->
Classification : `preauthorized` <!-- preauthorized/minor/major/emergency -->
Security impact: None <!-- describe if there is a security impact to this change -->

Automated tests: N/A
Manual tests: N/A <!-- or link to bug bash card -->
![image](https://user-images.githubusercontent.com/9314673/82819066-c3b0f700-9e6d-11ea-87d4-56e3d8e9aa4c.png)



Expected deployment date/time : 2020-05-25 PM <!-- YYYY-MM-DD HH:MM AM/PM -->
Expected downtime duration : 0 minutes
Rollout plan & rollback instructions: Revert github files and push to master

<!-- Change management policy:  https://docs.google.com/document/d/15Zz9it49fZl8Q4oKL-tL8kXPbnUPfdIUCEdv_x5P4vU/edit#-->
