### PR TITLE
add attachments apis

### DIFF
--- a/Smooch.postman_collection.json
+++ b/Smooch.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c493924e-09c1-4610-aca0-95a4de85d869",
+		"_postman_id": "bbf3d652-0ef9-4f15-b584-a9b480b71c52",
 		"name": "Smooch",
 		"description": "Smooch Public API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -216,120 +216,6 @@
 					},
 					"response": [
 						{
-							"name": "List App Keys",
-							"originalRequest": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{JWT}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/v1/apps/{{appId}}/keys",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"v1",
-										"apps",
-										"{{appId}}",
-										"keys"
-									]
-								},
-								"description": "### For more information\n- API Docs: [https://docs.smooch.io/rest/#list-app-keys](https://docs.smooch.io/rest/#list-app-keys)"
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "cache-control",
-									"value": "private, no-cache, no-store, must-revalidate",
-									"name": "cache-control",
-									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
-								},
-								{
-									"key": "content-length",
-									"value": "167",
-									"name": "content-length",
-									"description": "The length of the response body in octets (8-bit bytes)"
-								},
-								{
-									"key": "content-type",
-									"value": "application/json; charset=utf-8",
-									"name": "content-type",
-									"description": "The mime type of this content"
-								},
-								{
-									"key": "date",
-									"value": "Tue, 28 Aug 2018 19:35:12 GMT",
-									"name": "date",
-									"description": "The date and time that the message was sent"
-								},
-								{
-									"key": "etag",
-									"value": "W/\"a7-9irjQHQjxSD+7/cb3xbl2nrlMnU\"",
-									"name": "etag",
-									"description": "An identifier for a specific version of a resource, often a message digest"
-								},
-								{
-									"key": "expires",
-									"value": "-1",
-									"name": "expires",
-									"description": "Gives the date/time after which the response is considered stale"
-								},
-								{
-									"key": "pragma",
-									"value": "no-cache",
-									"name": "pragma",
-									"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
-								},
-								{
-									"key": "server",
-									"value": "nginx/1.13.8",
-									"name": "server",
-									"description": "A name for the server"
-								},
-								{
-									"key": "status",
-									"value": "200",
-									"name": "status",
-									"description": "Custom header"
-								},
-								{
-									"key": "strict-transport-security",
-									"value": "max-age=31536000",
-									"name": "strict-transport-security",
-									"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
-								},
-								{
-									"key": "x-content-type-options",
-									"value": "nosniff",
-									"name": "x-content-type-options",
-									"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
-								},
-								{
-									"key": "x-frame-options",
-									"value": "SAMEORIGIN",
-									"name": "x-frame-options",
-									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
-								},
-								{
-									"key": "x-xss-protection",
-									"value": "1; mode=block",
-									"name": "x-xss-protection",
-									"description": "Cross-site scripting (XSS) filter"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"keys\": [\n        {\n            \"name\": \"My App Key\",\n            \"secret\": \"jIMNXXQ8KHiNIvnIpsn0o0WnrJPGyTYhrqsRzTEG9oyZKT9WVU6V5F1p39eL9RVA9jSNk_av5b3wktn_2A\",\n            \"_id\": \"app_5b85a397334c22154d2f\"\n        }\n    ]\n}"
-						},
-						{
 							"name": "List App Keys #2",
 							"originalRequest": {
 								"method": "GET",
@@ -442,6 +328,120 @@
 							],
 							"cookie": [],
 							"body": "{\n  \"keys\": [\n    {\n      \"secret\": \"5XJ85yjUtRcaQu_pDINblPZb\",\n      \"name\": \"key1\",\n      \"_id\": \"app_5723a347f82ba0516cb4ea34\"\n    },\n    {\n      \"secret\": \"sTE74doRFsxtiwyT9JGCBQ6H\",\n      \"name\": \"key2\",\n      \"_id\": \"app_5723a347f82ba0516cb4ea35\"\n    }\n  ]\n}"
+						},
+						{
+							"name": "List App Keys",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{JWT}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/v1/apps/{{appId}}/keys",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"v1",
+										"apps",
+										"{{appId}}",
+										"keys"
+									]
+								},
+								"description": "### For more information\n- API Docs: [https://docs.smooch.io/rest/#list-app-keys](https://docs.smooch.io/rest/#list-app-keys)"
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "cache-control",
+									"value": "private, no-cache, no-store, must-revalidate",
+									"name": "cache-control",
+									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+								},
+								{
+									"key": "content-length",
+									"value": "167",
+									"name": "content-length",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json; charset=utf-8",
+									"name": "content-type",
+									"description": "The mime type of this content"
+								},
+								{
+									"key": "date",
+									"value": "Tue, 28 Aug 2018 19:35:12 GMT",
+									"name": "date",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"key": "etag",
+									"value": "W/\"a7-9irjQHQjxSD+7/cb3xbl2nrlMnU\"",
+									"name": "etag",
+									"description": "An identifier for a specific version of a resource, often a message digest"
+								},
+								{
+									"key": "expires",
+									"value": "-1",
+									"name": "expires",
+									"description": "Gives the date/time after which the response is considered stale"
+								},
+								{
+									"key": "pragma",
+									"value": "no-cache",
+									"name": "pragma",
+									"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
+								},
+								{
+									"key": "server",
+									"value": "nginx/1.13.8",
+									"name": "server",
+									"description": "A name for the server"
+								},
+								{
+									"key": "status",
+									"value": "200",
+									"name": "status",
+									"description": "Custom header"
+								},
+								{
+									"key": "strict-transport-security",
+									"value": "max-age=31536000",
+									"name": "strict-transport-security",
+									"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
+								},
+								{
+									"key": "x-content-type-options",
+									"value": "nosniff",
+									"name": "x-content-type-options",
+									"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
+								},
+								{
+									"key": "x-frame-options",
+									"value": "SAMEORIGIN",
+									"name": "x-frame-options",
+									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
+								},
+								{
+									"key": "x-xss-protection",
+									"value": "1; mode=block",
+									"name": "x-xss-protection",
+									"description": "Cross-site scripting (XSS) filter"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"keys\": [\n        {\n            \"name\": \"My App Key\",\n            \"secret\": \"jIMNXXQ8KHiNIvnIpsn0o0WnrJPGyTYhrqsRzTEG9oyZKT9WVU6V5F1p39eL9RVA9jSNk_av5b3wktn_2A\",\n            \"_id\": \"app_5b85a397334c22154d2f\"\n        }\n    ]\n}"
 						}
 					]
 				},
@@ -1328,125 +1328,6 @@
 					},
 					"response": [
 						{
-							"name": "Delete App User Example",
-							"originalRequest": {
-								"method": "DELETE",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{url}}/v1/apps/:appId/appusers/:userId",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"v1",
-										"apps",
-										":appId",
-										"appusers",
-										":userId"
-									],
-									"variable": [
-										{
-											"key": "appId",
-											"value": "{{appId}}"
-										},
-										{
-											"key": "userId",
-											"value": "{{userId}}"
-										}
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "Cache-Control",
-									"value": "private, no-cache, no-store, must-revalidate",
-									"name": "Cache-Control",
-									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
-								},
-								{
-									"key": "Connection",
-									"value": "keep-alive",
-									"name": "Connection",
-									"description": "Options that are desired for the connection"
-								},
-								{
-									"key": "Content-Length",
-									"value": "2",
-									"name": "Content-Length",
-									"description": "The length of the response body in octets (8-bit bytes)"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json; charset=utf-8",
-									"name": "Content-Type",
-									"description": "The mime type of this content"
-								},
-								{
-									"key": "Date",
-									"value": "Fri, 22 Jun 2018 15:16:23 GMT",
-									"name": "Date",
-									"description": "The date and time that the message was sent"
-								},
-								{
-									"key": "ETag",
-									"value": "W/\"2-vyGp6PvFo4RvsFtPoIWeCReyIC8\"",
-									"name": "ETag",
-									"description": "An identifier for a specific version of a resource, often a message digest"
-								},
-								{
-									"key": "Expires",
-									"value": "-1",
-									"name": "Expires",
-									"description": "Gives the date/time after which the response is considered stale"
-								},
-								{
-									"key": "Pragma",
-									"value": "no-cache",
-									"name": "Pragma",
-									"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
-								},
-								{
-									"key": "Server",
-									"value": "nginx/1.13.8",
-									"name": "Server",
-									"description": "A name for the server"
-								},
-								{
-									"key": "Strict-Transport-Security",
-									"value": "max-age=31536000",
-									"name": "Strict-Transport-Security",
-									"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
-								},
-								{
-									"key": "X-Content-Type-Options",
-									"value": "nosniff",
-									"name": "X-Content-Type-Options",
-									"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
-								},
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN",
-									"name": "X-Frame-Options",
-									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
-								},
-								{
-									"key": "X-XSS-Protection",
-									"value": "1; mode=block",
-									"name": "X-XSS-Protection",
-									"description": "Cross-site scripting (XSS) filter"
-								}
-							],
-							"cookie": [],
-							"body": "{}"
-						},
-						{
 							"name": "Delete App User Profile Example",
 							"originalRequest": {
 								"method": "DELETE",
@@ -1577,6 +1458,125 @@
 							],
 							"cookie": [],
 							"body": "{\"appUser\":{\"_id\":\"001484c9c86e65390b048455\",\"signedUpAt\":\"2018-06-20T15:14:26.306Z\",\"hasPaymentInfo\":false,\"conversationStarted\":true,\"credentialRequired\":true,\"clients\":[{\"lastSeen\":\"2018-06-22T13:09:40.204Z\",\"platform\":\"web\",\"id\":\"5a10afcec7824b51ab1c53f05719f583\",\"active\":true,\"primary\":true}],\"devices\":[{\"lastSeen\":\"2018-06-22T13:09:40.204Z\",\"platform\":\"web\",\"id\":\"5a10afcec7824b51ab1c53f05719f583\",\"active\":true,\"primary\":true}],\"pendingClients\":[],\"properties\":{}}}"
+						},
+						{
+							"name": "Delete App User Example",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{url}}/v1/apps/:appId/appusers/:userId",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"v1",
+										"apps",
+										":appId",
+										"appusers",
+										":userId"
+									],
+									"variable": [
+										{
+											"key": "appId",
+											"value": "{{appId}}"
+										},
+										{
+											"key": "userId",
+											"value": "{{userId}}"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Cache-Control",
+									"value": "private, no-cache, no-store, must-revalidate",
+									"name": "Cache-Control",
+									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive",
+									"name": "Connection",
+									"description": "Options that are desired for the connection"
+								},
+								{
+									"key": "Content-Length",
+									"value": "2",
+									"name": "Content-Length",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8",
+									"name": "Content-Type",
+									"description": "The mime type of this content"
+								},
+								{
+									"key": "Date",
+									"value": "Fri, 22 Jun 2018 15:16:23 GMT",
+									"name": "Date",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"key": "ETag",
+									"value": "W/\"2-vyGp6PvFo4RvsFtPoIWeCReyIC8\"",
+									"name": "ETag",
+									"description": "An identifier for a specific version of a resource, often a message digest"
+								},
+								{
+									"key": "Expires",
+									"value": "-1",
+									"name": "Expires",
+									"description": "Gives the date/time after which the response is considered stale"
+								},
+								{
+									"key": "Pragma",
+									"value": "no-cache",
+									"name": "Pragma",
+									"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
+								},
+								{
+									"key": "Server",
+									"value": "nginx/1.13.8",
+									"name": "Server",
+									"description": "A name for the server"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=31536000",
+									"name": "Strict-Transport-Security",
+									"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff",
+									"name": "X-Content-Type-Options",
+									"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN",
+									"name": "X-Frame-Options",
+									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "1; mode=block",
+									"name": "X-XSS-Protection",
+									"description": "Cross-site scripting (XSS) filter"
+								}
+							],
+							"cookie": [],
+							"body": "{}"
 						}
 					]
 				},
@@ -2054,7 +2054,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"type\": \"mailgun\",\n\t\"confirmation\": {\n\t\t\"type\": \"immediate\"\n\t},\n\t\"address\": \"their@email.com\"\n}"
+							"raw": "{\n\t\"type\": \"mailgun\",\n\t\"confirmation\": {\n\t\t\"type\": \"immediate\"\n\t},\n\t\"address\": \"their@email.com\"\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{url}}/{{apiVersion}}/apps/{{appId}}/appusers/{{appUserId}}/channels",
@@ -2692,8 +2695,8 @@
 							},
 							"status": "OK",
 							"code": 200,
-							"_postman_previewlanguage": "Text",
-							"header": [],
+							"_postman_previewlanguage": null,
+							"header": null,
 							"cookie": [],
 							"body": "{}"
 						}
@@ -2712,12 +2715,12 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"type": "text/javascript",
+								"id": "c2ef5536-90e2-4ad5-90d4-282960b5c7c2",
 								"exec": [
 									"",
 									""
 								],
-								"id": "cde85a20-3414-44e7-8e6e-cb81e71f02a4"
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2764,7 +2767,7 @@
 								{
 									"key": "access",
 									"value": "public",
-									"description": "The access level for the attachment. Currently the only available access level is public."
+									"description": "The access level for the attachment. Currently the only available access level is public and private."
 								},
 								{
 									"key": "for",
@@ -2945,8 +2948,7 @@
 								"exec": [
 									"",
 									""
-								],
-								"id": "27f02250-6eee-4fb9-864c-288d3fa97722"
+								]
 							}
 						}
 					],
@@ -3107,6 +3109,67 @@
 							"body": "{}"
 						}
 					]
+				},
+				{
+					"name": "Generate Media Token",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"paths\": [\"/apps/:appId\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{url}}/{{apiVersion}}/apps/{{appId}}/attachments/token",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"{{apiVersion}}",
+								"apps",
+								"{{appId}}",
+								"attachments",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Cookie",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "<token retrieved from calling the generate media token request>",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/{{apiVersion}}/apps/{{appId}}/attachments/cookie",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"{{apiVersion}}",
+								"apps",
+								"{{appId}}",
+								"attachments",
+								"cookie"
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"protocolProfileBehavior": {}
@@ -4251,8 +4314,10 @@
 							],
 							"variable": [
 								{
+									"id": "8e97be46-a809-4ec9-9928-d2c30ba73d9a",
 									"key": "messageId",
-									"value": ""
+									"value": "",
+									"type": "string"
 								}
 							]
 						},
@@ -5344,7 +5409,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "7e49e642-e6e9-4f90-b9f3-2ccc218aaf82",
+						"id": "97027122-9efc-49f5-8d7d-69723ce7bee9",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -5354,7 +5419,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "182216f3-4f90-43e6-ad12-bafeaf359d21",
+						"id": "b4f71282-4e8e-42e5-8412-8929a5625b21",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -6147,6 +6212,45 @@
 							},
 							"response": [
 								{
+									"name": "Web Messenger",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{JWT}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"type\": \"web\"\n}"
+										},
+										"url": {
+											"raw": "{{url}}/v1/apps/{{appId}}/integrations",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"v1",
+												"apps",
+												"{{appId}}",
+												"integrations"
+											]
+										},
+										"description": "### For more information\n- Guide Docs: [https://docs.smooch.io/guide/web-messenger/#installation](https://docs.smooch.io/guide/web-messenger/#installation)\n- API Docs: [https://docs.smooch.io/rest/#web-messenger-integration](https://docs.smooch.io/rest/#web-messenger-integration)"
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": "{\n  \"integration\": {\n    \"_id\": \"582dedf230e788746891281a\",\n    \"type\": \"web\",\n    \"integrationOrder\": [\n        \"59fc8466260f48003505228b\",\n        \"59d79780481d34002b7d3617\"\n    ],\n    \"originWhitelist\": [\n        \"https://yourdomain.com\"\n    ],\n    \"businessName\": \"Shoplifter\",\n    \"brandColor\": \"00ff00\",\n    \"fixedIntroPane\": true,\n    \"conversationColor\": \"dd00ee\",\n    \"backgroundImageUrl\": \"https://a-beautiful-tile.png\",\n    \"actionColor\": \"eeff00\",\n    \"displayStyle\": \"button\",\n    \"buttonWidth\": \"90\",\n    \"buttonHeight\": \"90\",\n    \"status\": \"active\"\n  }\n}"
+								},
+								{
 									"name": "Web Messenger ex 2",
 									"originalRequest": {
 										"method": "POST",
@@ -6287,45 +6391,6 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"integration\": {\n        \"type\": \"web\",\n        \"displayStyle\": \"button\",\n        \"actionColor\": \"0099ff\",\n        \"conversationColor\": \"0099ff\",\n        \"brandColor\": \"65758e\",\n        \"_id\": \"5b848334333333060022c53073\",\n        \"status\": \"active\"\n    }\n}"
-								},
-								{
-									"name": "Web Messenger",
-									"originalRequest": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{JWT}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n\t\"type\": \"web\"\n}"
-										},
-										"url": {
-											"raw": "{{url}}/v1/apps/{{appId}}/integrations",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"v1",
-												"apps",
-												"{{appId}}",
-												"integrations"
-											]
-										},
-										"description": "### For more information\n- Guide Docs: [https://docs.smooch.io/guide/web-messenger/#installation](https://docs.smooch.io/guide/web-messenger/#installation)\n- API Docs: [https://docs.smooch.io/rest/#web-messenger-integration](https://docs.smooch.io/rest/#web-messenger-integration)"
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "Text",
-									"header": [],
-									"cookie": [],
-									"body": "{\n  \"integration\": {\n    \"_id\": \"582dedf230e788746891281a\",\n    \"type\": \"web\",\n    \"integrationOrder\": [\n        \"59fc8466260f48003505228b\",\n        \"59d79780481d34002b7d3617\"\n    ],\n    \"originWhitelist\": [\n        \"https://yourdomain.com\"\n    ],\n    \"businessName\": \"Shoplifter\",\n    \"brandColor\": \"00ff00\",\n    \"fixedIntroPane\": true,\n    \"conversationColor\": \"dd00ee\",\n    \"backgroundImageUrl\": \"https://a-beautiful-tile.png\",\n    \"actionColor\": \"eeff00\",\n    \"displayStyle\": \"button\",\n    \"buttonWidth\": \"90\",\n    \"buttonHeight\": \"90\",\n    \"status\": \"active\"\n  }\n}"
 								}
 							]
 						},
@@ -6520,8 +6585,10 @@
 									],
 									"variable": [
 										{
+											"id": "9165ed13-a12c-4479-abd9-3dd6901ed6cb",
 											"key": "integrationId",
-											"value": ""
+											"value": "",
+											"type": "string"
 										}
 									]
 								},
@@ -6706,8 +6773,10 @@
 									],
 									"variable": [
 										{
+											"id": "3d78e856-c6db-414a-bbd2-e6ecacd2f43e",
 											"key": "integrationId",
-											"value": ""
+											"value": "",
+											"type": "string"
 										}
 									]
 								},
@@ -6906,8 +6975,10 @@
 									],
 									"variable": [
 										{
+											"id": "a5fe2bde-18fd-4e7c-9eda-a5fdcd61db64",
 											"key": "integrationId",
-											"value": ""
+											"value": "",
+											"type": "string"
 										}
 									]
 								},
@@ -7256,8 +7327,10 @@
 							],
 							"variable": [
 								{
+									"id": "19e170e1-8119-4016-afd3-760e1fbcc1d0",
 									"key": "integrationId",
-									"value": ""
+									"value": "",
+									"type": "string"
 								}
 							]
 						},
@@ -7413,8 +7486,10 @@
 							],
 							"variable": [
 								{
+									"id": "aac91fe8-4929-464e-a675-c96f9f238f92",
 									"key": "integrationId",
-									"value": ""
+									"value": "",
+									"type": "string"
 								}
 							]
 						},
@@ -8481,143 +8556,6 @@
 							},
 							"response": [
 								{
-									"name": "Action: quick reply Example",
-									"originalRequest": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"role\": \"appMaker\",\n    \"type\": \"text\",\n    \"text\": \"Help John understand how he’s doing. Please rate your conversation.\",\n    \"actions\": [\n    \t{\n\t        \"text\": \"😍\",\n\t        \"type\": \"reply\",\n\t        \"payload\": \"great\"\n    \t},\n    \t{\n\t        \"text\": \"🙂\",\n\t        \"type\": \"reply\",\n\t        \"payload\": \"good\"\n\n    \t},\n    \t{\n\t        \"text\": \"☹️\",\n\t        \"type\": \"reply\",\n\t        \"payload\": \"not so good\"\n\n    \t},\n    \t{\n\t        \"text\": \"😠\",\n\t        \"type\": \"reply\",\n\t        \"payload\": \"really not good at all\"\n\n    \t}\n    ]\n}"
-										},
-										"url": {
-											"raw": "{{url}}/v1/apps/:appId/appusers/:userId/messages",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"v1",
-												"apps",
-												":appId",
-												"appusers",
-												":userId",
-												"messages"
-											],
-											"variable": [
-												{
-													"key": "appId",
-													"value": "{{appId}}"
-												},
-												{
-													"key": "userId",
-													"value": "{{userId}}"
-												}
-											]
-										}
-									},
-									"status": "Created",
-									"code": 201,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Cache-Control",
-											"value": "private, no-cache, no-store, must-revalidate",
-											"name": "Cache-Control",
-											"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
-										},
-										{
-											"key": "Connection",
-											"value": "keep-alive",
-											"name": "Connection",
-											"description": "Options that are desired for the connection"
-										},
-										{
-											"key": "Content-Length",
-											"value": "872",
-											"name": "Content-Length",
-											"description": "The length of the response body in octets (8-bit bytes)"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8",
-											"name": "Content-Type",
-											"description": "The mime type of this content"
-										},
-										{
-											"key": "Date",
-											"value": "Thu, 21 Jun 2018 19:22:07 GMT",
-											"name": "Date",
-											"description": "The date and time that the message was sent"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"368-AgMu7cLbMdf50KdGniH+mHqgBHQ\"",
-											"name": "ETag",
-											"description": "An identifier for a specific version of a resource, often a message digest"
-										},
-										{
-											"key": "Expires",
-											"value": "-1",
-											"name": "Expires",
-											"description": "Gives the date/time after which the response is considered stale"
-										},
-										{
-											"key": "Poll-Interval",
-											"value": "30",
-											"name": "Poll-Interval",
-											"description": "Custom header"
-										},
-										{
-											"key": "Pragma",
-											"value": "no-cache",
-											"name": "Pragma",
-											"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
-										},
-										{
-											"key": "Server",
-											"value": "nginx/1.13.8",
-											"name": "Server",
-											"description": "A name for the server"
-										},
-										{
-											"key": "Strict-Transport-Security",
-											"value": "max-age=31536000",
-											"name": "Strict-Transport-Security",
-											"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
-										},
-										{
-											"key": "Vary",
-											"value": "X-HTTP-Method-Override",
-											"name": "Vary",
-											"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
-										},
-										{
-											"key": "X-Content-Type-Options",
-											"value": "nosniff",
-											"name": "X-Content-Type-Options",
-											"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
-										},
-										{
-											"key": "X-Frame-Options",
-											"value": "SAMEORIGIN",
-											"name": "X-Frame-Options",
-											"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
-										},
-										{
-											"key": "X-XSS-Protection",
-											"value": "1; mode=block",
-											"name": "X-XSS-Protection",
-											"description": "Cross-site scripting (XSS) filter"
-										}
-									],
-									"cookie": [],
-									"body": "{\"message\":{\"text\":\"Help John understand how he’s doing. Please rate your conversation.\",\"actions\":[{\"text\":\"😍\",\"payload\":\"great\",\"_id\":\"5b2bfadff453be00221e7466\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"🙂\",\"payload\":\"good\",\"_id\":\"5b2bfadff453be00221e7465\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"☹️\",\"payload\":\"not so good\",\"_id\":\"5b2bfadff453be00221e7464\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"😠\",\"payload\":\"really not good at all\",\"_id\":\"5b2bfadff453be00221e7463\",\"uri\":\"\",\"type\":\"reply\"}],\"type\":\"text\",\"role\":\"appMaker\",\"received\":1529608927.039,\"authorId\":\"00uejytoekz520ZEG0h7\",\"avatarUrl\":\"https://media.smooch.io/5ac3da9539fe6c0022447259/icons/appicon.jpg\",\"name\":\"Galifrey\",\"_id\":\"5b2bfadff453be00221e7462\",\"source\":{\"type\":\"api\"}},\"conversation\":{\"unreadCount\":1,\"_id\":\"884ac26bfa519a0bb4cb0162\",\"appMakerLastRead\":1529608927.039,\"appUserLastRead\":1529608552.93}}"
-								},
-								{
 									"name": "Action:  location request Example",
 									"originalRequest": {
 										"method": "POST",
@@ -8753,44 +8691,7 @@
 									],
 									"cookie": [],
 									"body": "{\"message\":{\"text\":\"Let us know where you are.\",\"actions\":[{\"text\":\"Send Location\",\"_id\":\"5b2cf7422bb60400222bf299\",\"uri\":\"\",\"type\":\"locationRequest\"}],\"type\":\"text\",\"role\":\"appMaker\",\"received\":1529673538.639,\"authorId\":\"00uejytoekz520ZEG0h7\",\"avatarUrl\":\"https://media.smooch.io/5ac3da9539fe6c0022447259/icons/appicon.jpg\",\"name\":\"Galifrey\",\"_id\":\"5b2cf7422bb60400222bf298\",\"source\":{\"type\":\"api\"}},\"conversation\":{\"unreadCount\":1,\"_id\":\"884ac26bfa519a0bb4cb0162\",\"appMakerLastRead\":1529673538.639,\"appUserLastRead\":1529672980.196}}"
-								}
-							]
-						},
-						{
-							"name": "Action:  share Message",
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "Authorization",
-										"value": "Bearer {{JWT}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"role\": \"appMaker\",\n    \"type\": \"carousel\",\n    \"items\": [\n    \t{\n\t        \"title\": \"Scandinave Getaway\",\n\t        \"description\": \"Enjoy massage treatments situated in a serene natural forest with an on-site bistro serving healthy local fare\",\n\t        \"mediaUrl\": \"https://www.scandinave.com/app/uploads/sites/5/2017/01/2015-upper-hot-bath-hp-820x779.jpg\",\n\t        \"mediaType\": \"image/jpeg\",\n\t        \"actions\": [\n\t        \t{\n\t        \t\t\"type\": \"share\"\n\t        \t}\n\t        ]\n    \t}\n    ]\n}"
 								},
-								"url": {
-									"raw": "{{url}}/{{apiVersion}}/apps/{{appId}}/appusers/{{appUserId}}/messages",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"{{apiVersion}}",
-										"apps",
-										"{{appId}}",
-										"appusers",
-										"{{appUserId}}",
-										"messages"
-									]
-								},
-								"description": "_Share Buttons are currently only supported in Facebook Messenger carousels._\n### For more information\n- Guide: [https://docs.smooch.io/guide/sending-messages/](https://docs.smooch.io/guide/sending-messages/)\n- API Docs: [https://docs.smooch.io/rest/#message-actions](https://docs.smooch.io/rest/#message-actions)\n- Carousels: [https://docs.smooch.io/rest/?shell#carousel](https://docs.smooch.io/rest/?shell#carousel)\n\nSee the [capabilities grid](https://docs.smooch.io/guide/channel-capabilities/) for message-type support across channels."
-							},
-							"response": [
 								{
 									"name": "Action: quick reply Example",
 									"originalRequest": {
@@ -8927,7 +8828,44 @@
 									],
 									"cookie": [],
 									"body": "{\"message\":{\"text\":\"Help John understand how he’s doing. Please rate your conversation.\",\"actions\":[{\"text\":\"😍\",\"payload\":\"great\",\"_id\":\"5b2bfadff453be00221e7466\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"🙂\",\"payload\":\"good\",\"_id\":\"5b2bfadff453be00221e7465\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"☹️\",\"payload\":\"not so good\",\"_id\":\"5b2bfadff453be00221e7464\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"😠\",\"payload\":\"really not good at all\",\"_id\":\"5b2bfadff453be00221e7463\",\"uri\":\"\",\"type\":\"reply\"}],\"type\":\"text\",\"role\":\"appMaker\",\"received\":1529608927.039,\"authorId\":\"00uejytoekz520ZEG0h7\",\"avatarUrl\":\"https://media.smooch.io/5ac3da9539fe6c0022447259/icons/appicon.jpg\",\"name\":\"Galifrey\",\"_id\":\"5b2bfadff453be00221e7462\",\"source\":{\"type\":\"api\"}},\"conversation\":{\"unreadCount\":1,\"_id\":\"884ac26bfa519a0bb4cb0162\",\"appMakerLastRead\":1529608927.039,\"appUserLastRead\":1529608552.93}}"
+								}
+							]
+						},
+						{
+							"name": "Action:  share Message",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{JWT}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"role\": \"appMaker\",\n    \"type\": \"carousel\",\n    \"items\": [\n    \t{\n\t        \"title\": \"Scandinave Getaway\",\n\t        \"description\": \"Enjoy massage treatments situated in a serene natural forest with an on-site bistro serving healthy local fare\",\n\t        \"mediaUrl\": \"https://www.scandinave.com/app/uploads/sites/5/2017/01/2015-upper-hot-bath-hp-820x779.jpg\",\n\t        \"mediaType\": \"image/jpeg\",\n\t        \"actions\": [\n\t        \t{\n\t        \t\t\"type\": \"share\"\n\t        \t}\n\t        ]\n    \t}\n    ]\n}"
 								},
+								"url": {
+									"raw": "{{url}}/{{apiVersion}}/apps/{{appId}}/appusers/{{appUserId}}/messages",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"{{apiVersion}}",
+										"apps",
+										"{{appId}}",
+										"appusers",
+										"{{appUserId}}",
+										"messages"
+									]
+								},
+								"description": "_Share Buttons are currently only supported in Facebook Messenger carousels._\n### For more information\n- Guide: [https://docs.smooch.io/guide/sending-messages/](https://docs.smooch.io/guide/sending-messages/)\n- API Docs: [https://docs.smooch.io/rest/#message-actions](https://docs.smooch.io/rest/#message-actions)\n- Carousels: [https://docs.smooch.io/rest/?shell#carousel](https://docs.smooch.io/rest/?shell#carousel)\n\nSee the [capabilities grid](https://docs.smooch.io/guide/channel-capabilities/) for message-type support across channels."
+							},
+							"response": [
 								{
 									"name": "Action:  share Example",
 									"originalRequest": {
@@ -9064,6 +9002,143 @@
 									],
 									"cookie": [],
 									"body": "{\"message\":{\"text\":\"1. Scandinave Getaway\\nEnjoy massage treatments situated in a serene natural forest with an on-site bistro serving healthy local fare\\n\",\"items\":[{\"title\":\"Scandinave Getaway\",\"description\":\"Enjoy massage treatments situated in a serene natural forest with an on-site bistro serving healthy local fare\",\"mediaUrl\":\"https://www.scandinave.com/app/uploads/sites/5/2017/01/2015-upper-hot-bath-hp-820x779.jpg\",\"mediaType\":\"image/jpeg\",\"_id\":\"5b2cf9653e3adc00228ba421\",\"actions\":[{\"_id\":\"5b2cf9653e3adc00228ba422\",\"uri\":\"\",\"type\":\"share\"}]}],\"type\":\"carousel\",\"role\":\"appMaker\",\"received\":1529674085.179,\"authorId\":\"00uejytoekz520ZEG0h7\",\"avatarUrl\":\"https://media.smooch.io/5ac3da9539fe6c0022447259/icons/appicon.jpg\",\"name\":\"Galifrey\",\"_id\":\"5b2cf9653e3adc00228ba420\",\"source\":{\"type\":\"api\"}},\"conversation\":{\"unreadCount\":2,\"_id\":\"884ac26bfa519a0bb4cb0162\",\"appMakerLastRead\":1529674085.179,\"appUserLastRead\":1529672980.196}}"
+								},
+								{
+									"name": "Action: quick reply Example",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"role\": \"appMaker\",\n    \"type\": \"text\",\n    \"text\": \"Help John understand how he’s doing. Please rate your conversation.\",\n    \"actions\": [\n    \t{\n\t        \"text\": \"😍\",\n\t        \"type\": \"reply\",\n\t        \"payload\": \"great\"\n    \t},\n    \t{\n\t        \"text\": \"🙂\",\n\t        \"type\": \"reply\",\n\t        \"payload\": \"good\"\n\n    \t},\n    \t{\n\t        \"text\": \"☹️\",\n\t        \"type\": \"reply\",\n\t        \"payload\": \"not so good\"\n\n    \t},\n    \t{\n\t        \"text\": \"😠\",\n\t        \"type\": \"reply\",\n\t        \"payload\": \"really not good at all\"\n\n    \t}\n    ]\n}"
+										},
+										"url": {
+											"raw": "{{url}}/v1/apps/:appId/appusers/:userId/messages",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"v1",
+												"apps",
+												":appId",
+												"appusers",
+												":userId",
+												"messages"
+											],
+											"variable": [
+												{
+													"key": "appId",
+													"value": "{{appId}}"
+												},
+												{
+													"key": "userId",
+													"value": "{{userId}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Cache-Control",
+											"value": "private, no-cache, no-store, must-revalidate",
+											"name": "Cache-Control",
+											"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive",
+											"name": "Connection",
+											"description": "Options that are desired for the connection"
+										},
+										{
+											"key": "Content-Length",
+											"value": "872",
+											"name": "Content-Length",
+											"description": "The length of the response body in octets (8-bit bytes)"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8",
+											"name": "Content-Type",
+											"description": "The mime type of this content"
+										},
+										{
+											"key": "Date",
+											"value": "Thu, 21 Jun 2018 19:22:07 GMT",
+											"name": "Date",
+											"description": "The date and time that the message was sent"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"368-AgMu7cLbMdf50KdGniH+mHqgBHQ\"",
+											"name": "ETag",
+											"description": "An identifier for a specific version of a resource, often a message digest"
+										},
+										{
+											"key": "Expires",
+											"value": "-1",
+											"name": "Expires",
+											"description": "Gives the date/time after which the response is considered stale"
+										},
+										{
+											"key": "Poll-Interval",
+											"value": "30",
+											"name": "Poll-Interval",
+											"description": "Custom header"
+										},
+										{
+											"key": "Pragma",
+											"value": "no-cache",
+											"name": "Pragma",
+											"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
+										},
+										{
+											"key": "Server",
+											"value": "nginx/1.13.8",
+											"name": "Server",
+											"description": "A name for the server"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000",
+											"name": "Strict-Transport-Security",
+											"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
+										},
+										{
+											"key": "Vary",
+											"value": "X-HTTP-Method-Override",
+											"name": "Vary",
+											"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff",
+											"name": "X-Content-Type-Options",
+											"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN",
+											"name": "X-Frame-Options",
+											"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
+										},
+										{
+											"key": "X-XSS-Protection",
+											"value": "1; mode=block",
+											"name": "X-XSS-Protection",
+											"description": "Cross-site scripting (XSS) filter"
+										}
+									],
+									"cookie": [],
+									"body": "{\"message\":{\"text\":\"Help John understand how he’s doing. Please rate your conversation.\",\"actions\":[{\"text\":\"😍\",\"payload\":\"great\",\"_id\":\"5b2bfadff453be00221e7466\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"🙂\",\"payload\":\"good\",\"_id\":\"5b2bfadff453be00221e7465\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"☹️\",\"payload\":\"not so good\",\"_id\":\"5b2bfadff453be00221e7464\",\"uri\":\"\",\"type\":\"reply\"},{\"text\":\"😠\",\"payload\":\"really not good at all\",\"_id\":\"5b2bfadff453be00221e7463\",\"uri\":\"\",\"type\":\"reply\"}],\"type\":\"text\",\"role\":\"appMaker\",\"received\":1529608927.039,\"authorId\":\"00uejytoekz520ZEG0h7\",\"avatarUrl\":\"https://media.smooch.io/5ac3da9539fe6c0022447259/icons/appicon.jpg\",\"name\":\"Galifrey\",\"_id\":\"5b2bfadff453be00221e7462\",\"source\":{\"type\":\"api\"}},\"conversation\":{\"unreadCount\":1,\"_id\":\"884ac26bfa519a0bb4cb0162\",\"appMakerLastRead\":1529608927.039,\"appUserLastRead\":1529608552.93}}"
 								},
 								{
 									"name": "Action:  location request Example",
@@ -9210,7 +9285,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "2dc8e801-9689-4adc-946f-30e560ee3b43",
+								"id": "842c1e3d-0bdc-4832-9920-a3d65d49d056",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -9220,7 +9295,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7688d439-495d-43fc-898d-2c6e7073835f",
+								"id": "9659bf7d-76cc-4066-b55a-4aab286f5b72",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -9237,7 +9312,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "0896f572-32da-4e72-a2d2-64e6a4d147df",
+								"id": "390f7fb6-87fc-4716-af40-7c5a99f32c48",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -9423,7 +9498,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "e45fe79e-518c-4a34-b1cf-39364815a5f2",
+								"id": "dfa4ad8b-93ac-49a8-8a3d-3d1c484dc27e",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -9609,6 +9684,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
+								"id": "eb56f021-49f5-44e5-b3c4-d97c6f7b9a87",
 								"type": "text/javascript",
 								"exec": [
 									"pm.globals.set(\"userId\", \"8a933a26543ea07db20f06b2\");",
@@ -9616,8 +9692,7 @@
 									"pm.globals.set(\"appUser\", \"5b17d6de16545d00239d3cd1\");",
 									"",
 									"pm.globals.set(\"url\", \"https://api.smooch.io\");"
-								],
-								"id": "c3546baf-799d-4118-82c1-413e30d4fd27"
+								]
 							}
 						}
 					],
@@ -10458,7 +10533,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "5be98c12-0add-4cd4-bd76-7e197f6165d0",
+								"id": "390f7fb6-87fc-4716-af40-7c5a99f32c48",
 								"type": "text/javascript",
 								"exec": [
 									""
@@ -10992,7 +11067,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "1a69ecfe-b1c0-495c-9ad2-79f77b88e786",
+						"id": "a407c4d0-5f5e-4db5-be55-4719b9c872ad",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -11002,7 +11077,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "fb7e6605-5c44-471b-8657-3b8bd99749ce",
+						"id": "9d34834d-164e-4679-bb8a-0b3e90231893",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -11078,7 +11153,7 @@
 							}
 						],
 						"url": {
-							"raw": "https://app.smooch.io/oauth/authorize?client_id=&response_type=code",
+							"raw": "https://app.smooch.io/oauth/authorize?client_id&response_type=code",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -11133,7 +11208,7 @@
 							}
 						],
 						"url": {
-							"raw": "https://app.smooch.io/oauth/token?code=&grant_type=&client_id=&client_secret=",
+							"raw": "https://app.smooch.io/oauth/token?code&grant_type=&client_id&client_secret",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -11303,7 +11378,10 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n        \"role\": \"appMaker\",\n        \"text\": \"Hello there\",\n        \"override\": {\n                \"apple\": {\n                        \"payload\": {\n                                \"type\": \"interactive\",\n                                \"interactiveDataRef\": {\n                                        \"title\": \"FoodPicker\",\n                                        \"bid\": \"com.apple.messages.MSMessageExtensionBalloonPlugin:0000000000:com.apple.icloud.apps.messages.business.extension\",\n                                        \"size\": 100159,\n                                        \"signature-base64\": \"0ACF958GF9846BADE655423\",\n                                        \"url\": \"https://p97-content.icloud.com\",\n                                        \"owner\": \"M39303332653438322d396338342d313165372d613330332d633735336231626666366661.C01USN00\",\n                                        \"key\": \"00260450bb05cd4597a8ae706199f685c0f6fafee4b6c3e1375771c472f4149e29\"\n                                }\n                        }\n                }\n        }\n}"
+									"raw": "{\n        \"role\": \"appMaker\",\n        \"text\": \"Hello there\",\n        \"override\": {\n                \"apple\": {\n                        \"payload\": {\n                                \"type\": \"interactive\",\n                                \"interactiveDataRef\": {\n                                        \"title\": \"FoodPicker\",\n                                        \"bid\": \"com.apple.messages.MSMessageExtensionBalloonPlugin:0000000000:com.apple.icloud.apps.messages.business.extension\",\n                                        \"size\": 100159,\n                                        \"signature-base64\": \"0ACF958GF9846BADE655423\",\n                                        \"url\": \"https://p97-content.icloud.com\",\n                                        \"owner\": \"M39303332653438322d396338342d313165372d613330332d633735336231626666366661.C01USN00\",\n                                        \"key\": \"00260450bb05cd4597a8ae706199f685c0f6fafee4b6c3e1375771c472f4149e29\"\n                                }\n                        }\n                }\n        }\n}",
+									"options": {
+										"raw": {}
+									}
 								},
 								"url": {
 									"raw": "{{url}}/{{apiVersion}}/apps/{{appId}}/appusers/{{appUserId}}/messages",
@@ -12940,14 +13018,132 @@
 							],
 							"variable": [
 								{
+									"id": "03c18097-86c3-4478-a526-c560cb855c70",
 									"key": "integrationId",
-									"value": "{{integrationId}}"
+									"value": "{{integrationId}}",
+									"type": "string"
 								}
 							]
 						},
 						"description": "### For more information\n- Not available on all channels \n- Guide: [https://docs.smooch.io/guide/facebook-messenger/#persistent-menu](https://docs.smooch.io/guide/facebook-messenger/#persistent-menu)\n- [https://docs.smooch.io/guide/wechat/#persistent-menu](https://docs.smooch.io/guide/wechat/#persistent-menu)\n- API Docs: [https://docs.smooch.io/rest/#get-integration-menu](https://docs.smooch.io/rest/#get-integration-menu)"
 					},
 					"response": [
+						{
+							"name": "Get Integration Menu",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{JWT}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/v1/apps/{{appId}}/integrations/{{integrationId}}/menu",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"v1",
+										"apps",
+										"{{appId}}",
+										"integrations",
+										"{{integrationId}}",
+										"menu"
+									]
+								},
+								"description": "### For more information\n- Not available on all channels \n- Guide: [https://docs.smooch.io/guide/facebook-messenger/#persistent-menu](https://docs.smooch.io/guide/facebook-messenger/#persistent-menu)\n- [https://docs.smooch.io/guide/wechat/#persistent-menu](https://docs.smooch.io/guide/wechat/#persistent-menu)\n- API Docs: [https://docs.smooch.io/rest/#get-integration-menu](https://docs.smooch.io/rest/#get-integration-menu)"
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "cache-control",
+									"value": "private, no-cache, no-store, must-revalidate",
+									"name": "cache-control",
+									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+								},
+								{
+									"key": "content-length",
+									"value": "252",
+									"name": "content-length",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json; charset=utf-8",
+									"name": "content-type",
+									"description": "The mime type of this content"
+								},
+								{
+									"key": "date",
+									"value": "Tue, 28 Aug 2018 17:25:35 GMT",
+									"name": "date",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"key": "etag",
+									"value": "W/\"fc-BVsjftDt4fpq1XMeyQcNToqaVZA\"",
+									"name": "etag",
+									"description": "An identifier for a specific version of a resource, often a message digest"
+								},
+								{
+									"key": "expires",
+									"value": "-1",
+									"name": "expires",
+									"description": "Gives the date/time after which the response is considered stale"
+								},
+								{
+									"key": "pragma",
+									"value": "no-cache",
+									"name": "pragma",
+									"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
+								},
+								{
+									"key": "server",
+									"value": "nginx/1.13.8",
+									"name": "server",
+									"description": "A name for the server"
+								},
+								{
+									"key": "status",
+									"value": "200",
+									"name": "status",
+									"description": "Custom header"
+								},
+								{
+									"key": "strict-transport-security",
+									"value": "max-age=31536000",
+									"name": "strict-transport-security",
+									"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
+								},
+								{
+									"key": "x-content-type-options",
+									"value": "nosniff",
+									"name": "x-content-type-options",
+									"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
+								},
+								{
+									"key": "x-frame-options",
+									"value": "SAMEORIGIN",
+									"name": "x-frame-options",
+									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
+								},
+								{
+									"key": "x-xss-protection",
+									"value": "1; mode=block",
+									"name": "x-xss-protection",
+									"description": "Cross-site scripting (XSS) filter"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"menu\": {\n        \"items\": [\n            {\n                \"type\": \"link\",\n                \"text\": \"Smooch\",\n                \"uri\": \"http://smooch.io\",\n                \"_id\": \"57b331fbf1c6aebf940dc7\"\n            },\n            {\n                \"type\": \"postback\",\n                \"text\": \"Hello\",\n                \"payload\": \"HELLO\",\n                \"_id\": \"57b331fbf1c6aeba1f940dc6\"\n            }\n        ]\n    }\n}"
+						},
 						{
 							"name": "Get Integration Menu #2",
 							"originalRequest": {
@@ -13177,122 +13373,6 @@
 							],
 							"cookie": [],
 							"body": "{\n    \"integration\": {\n        \"backgroundImageUrl\": null,\n        \"originWhitelist\": null,\n        \"integrationOrder\": null,\n        \"displayStyle\": \"button\",\n        \"actionColor\": \"0099ff\",\n        \"conversationColor\": \"0099ff\",\n        \"brandColor\": \"65758e\",\n        \"_id\": \"5b84833450460022c53073\",\n        \"type\": \"web\",\n        \"status\": \"active\"\n    }\n}"
-						},
-						{
-							"name": "Get Integration Menu",
-							"originalRequest": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{JWT}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/v1/apps/{{appId}}/integrations/{{integrationId}}/menu",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"v1",
-										"apps",
-										"{{appId}}",
-										"integrations",
-										"{{integrationId}}",
-										"menu"
-									]
-								},
-								"description": "### For more information\n- Not available on all channels \n- Guide: [https://docs.smooch.io/guide/facebook-messenger/#persistent-menu](https://docs.smooch.io/guide/facebook-messenger/#persistent-menu)\n- [https://docs.smooch.io/guide/wechat/#persistent-menu](https://docs.smooch.io/guide/wechat/#persistent-menu)\n- API Docs: [https://docs.smooch.io/rest/#get-integration-menu](https://docs.smooch.io/rest/#get-integration-menu)"
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "cache-control",
-									"value": "private, no-cache, no-store, must-revalidate",
-									"name": "cache-control",
-									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
-								},
-								{
-									"key": "content-length",
-									"value": "252",
-									"name": "content-length",
-									"description": "The length of the response body in octets (8-bit bytes)"
-								},
-								{
-									"key": "content-type",
-									"value": "application/json; charset=utf-8",
-									"name": "content-type",
-									"description": "The mime type of this content"
-								},
-								{
-									"key": "date",
-									"value": "Tue, 28 Aug 2018 17:25:35 GMT",
-									"name": "date",
-									"description": "The date and time that the message was sent"
-								},
-								{
-									"key": "etag",
-									"value": "W/\"fc-BVsjftDt4fpq1XMeyQcNToqaVZA\"",
-									"name": "etag",
-									"description": "An identifier for a specific version of a resource, often a message digest"
-								},
-								{
-									"key": "expires",
-									"value": "-1",
-									"name": "expires",
-									"description": "Gives the date/time after which the response is considered stale"
-								},
-								{
-									"key": "pragma",
-									"value": "no-cache",
-									"name": "pragma",
-									"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
-								},
-								{
-									"key": "server",
-									"value": "nginx/1.13.8",
-									"name": "server",
-									"description": "A name for the server"
-								},
-								{
-									"key": "status",
-									"value": "200",
-									"name": "status",
-									"description": "Custom header"
-								},
-								{
-									"key": "strict-transport-security",
-									"value": "max-age=31536000",
-									"name": "strict-transport-security",
-									"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
-								},
-								{
-									"key": "x-content-type-options",
-									"value": "nosniff",
-									"name": "x-content-type-options",
-									"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
-								},
-								{
-									"key": "x-frame-options",
-									"value": "SAMEORIGIN",
-									"name": "x-frame-options",
-									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
-								},
-								{
-									"key": "x-xss-protection",
-									"value": "1; mode=block",
-									"name": "x-xss-protection",
-									"description": "Cross-site scripting (XSS) filter"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"menu\": {\n        \"items\": [\n            {\n                \"type\": \"link\",\n                \"text\": \"Smooch\",\n                \"uri\": \"http://smooch.io\",\n                \"_id\": \"57b331fbf1c6aebf940dc7\"\n            },\n            {\n                \"type\": \"postback\",\n                \"text\": \"Hello\",\n                \"payload\": \"HELLO\",\n                \"_id\": \"57b331fbf1c6aeba1f940dc6\"\n            }\n        ]\n    }\n}"
 						}
 					]
 				},
@@ -13329,158 +13409,16 @@
 							],
 							"variable": [
 								{
+									"id": "a298f621-a804-4de1-9caa-85131dd2301c",
 									"key": "integrationId",
-									"value": "{{integrationId}}"
+									"value": "{{integrationId}}",
+									"type": "string"
 								}
 							]
 						},
 						"description": "### For more information\n- Not available on all channels \n- Guide: [https://docs.smooch.io/guide/facebook-messenger/#persistent-menu](https://docs.smooch.io/guide/facebook-messenger/#persistent-menu)\n- [https://docs.smooch.io/guide/wechat/#persistent-menu](https://docs.smooch.io/guide/wechat/#persistent-menu)\n- API Docs: [https://docs.smooch.io/rest/#update-integration-menu](https://docs.smooch.io/rest/#update-integration-menu)"
 					},
 					"response": [
-						{
-							"name": "Update Integration Menu",
-							"originalRequest": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{JWT}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{url}}/v1/apps/{{appId}}/integrations/{{integrationId}}/menu",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"v1",
-										"apps",
-										"{{appId}}",
-										"integrations",
-										"{{integrationId}}",
-										"menu"
-									]
-								},
-								"description": "### For more information\n- Not available on all channels \n- Guide: [https://docs.smooch.io/guide/facebook-messenger/#persistent-menu](https://docs.smooch.io/guide/facebook-messenger/#persistent-menu)\n- [https://docs.smooch.io/guide/wechat/#persistent-menu](https://docs.smooch.io/guide/wechat/#persistent-menu)\n- API Docs: [https://docs.smooch.io/rest/#update-integration-menu](https://docs.smooch.io/rest/#update-integration-menu)"
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "access-control-allow-credentials",
-									"value": "true",
-									"name": "access-control-allow-credentials",
-									"description": "Indicates whether or not the response to the request can be exposed when the credentials flag is true. When used as part of a response to a preflight request, this indicates whether or not the actual request can be made using credentials."
-								},
-								{
-									"key": "access-control-allow-origin",
-									"value": "chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop",
-									"name": "access-control-allow-origin",
-									"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
-								},
-								{
-									"key": "access-control-expose-headers",
-									"value": "Retry-After",
-									"name": "access-control-expose-headers",
-									"description": "Lets a server whitelist headers that browsers are allowed to access."
-								},
-								{
-									"key": "cache-control",
-									"value": "private, no-cache, no-store, must-revalidate",
-									"name": "cache-control",
-									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
-								},
-								{
-									"key": "content-length",
-									"value": "252",
-									"name": "content-length",
-									"description": "The length of the response body in octets (8-bit bytes)"
-								},
-								{
-									"key": "content-type",
-									"value": "application/json; charset=utf-8",
-									"name": "content-type",
-									"description": "The mime type of this content"
-								},
-								{
-									"key": "date",
-									"value": "Tue, 28 Aug 2018 17:26:34 GMT",
-									"name": "date",
-									"description": "The date and time that the message was sent"
-								},
-								{
-									"key": "etag",
-									"value": "W/\"fc-LvHOyiaj5/VWWtdeQl6ib5dUJ/Y\"",
-									"name": "etag",
-									"description": "An identifier for a specific version of a resource, often a message digest"
-								},
-								{
-									"key": "expires",
-									"value": "-1",
-									"name": "expires",
-									"description": "Gives the date/time after which the response is considered stale"
-								},
-								{
-									"key": "pragma",
-									"value": "no-cache",
-									"name": "pragma",
-									"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
-								},
-								{
-									"key": "server",
-									"value": "nginx/1.13.8",
-									"name": "server",
-									"description": "A name for the server"
-								},
-								{
-									"key": "status",
-									"value": "200",
-									"name": "status",
-									"description": "Custom header"
-								},
-								{
-									"key": "strict-transport-security",
-									"value": "max-age=31536000",
-									"name": "strict-transport-security",
-									"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
-								},
-								{
-									"key": "vary",
-									"value": "Origin",
-									"name": "vary",
-									"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
-								},
-								{
-									"key": "x-content-type-options",
-									"value": "nosniff",
-									"name": "x-content-type-options",
-									"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
-								},
-								{
-									"key": "x-frame-options",
-									"value": "SAMEORIGIN",
-									"name": "x-frame-options",
-									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
-								},
-								{
-									"key": "x-xss-protection",
-									"value": "1; mode=block",
-									"name": "x-xss-protection",
-									"description": "Cross-site scripting (XSS) filter"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"menu\": {\n        \"items\": [\n            {\n                \"type\": \"link\",\n                \"text\": \"Smooch\",\n                \"uri\": \"http://smooch.io\",\n                \"_id\": \"57b331fbf1c6a1f940dc7\"\n            }\n        ]\n    }\n}"
-						},
 						{
 							"name": "Update Integration Menu #2",
 							"originalRequest": {
@@ -13624,6 +13562,150 @@
 							],
 							"cookie": [],
 							"body": "{\n    \"menu\": {\n        \"items\": [\n            {\n                \"uri\": \"http://smooch.io\",\n                \"text\": \"Smooch\",\n                \"type\": \"link\",\n                \"_id\": \"5b8591725e002213ed4d\"\n            }\n        ],\n        \"settings\": {\n            \"inputEnabled\": true\n        }\n    }\n}"
+						},
+						{
+							"name": "Update Integration Menu",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{JWT}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{url}}/v1/apps/{{appId}}/integrations/{{integrationId}}/menu",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"v1",
+										"apps",
+										"{{appId}}",
+										"integrations",
+										"{{integrationId}}",
+										"menu"
+									]
+								},
+								"description": "### For more information\n- Not available on all channels \n- Guide: [https://docs.smooch.io/guide/facebook-messenger/#persistent-menu](https://docs.smooch.io/guide/facebook-messenger/#persistent-menu)\n- [https://docs.smooch.io/guide/wechat/#persistent-menu](https://docs.smooch.io/guide/wechat/#persistent-menu)\n- API Docs: [https://docs.smooch.io/rest/#update-integration-menu](https://docs.smooch.io/rest/#update-integration-menu)"
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-credentials",
+									"value": "true",
+									"name": "access-control-allow-credentials",
+									"description": "Indicates whether or not the response to the request can be exposed when the credentials flag is true. When used as part of a response to a preflight request, this indicates whether or not the actual request can be made using credentials."
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop",
+									"name": "access-control-allow-origin",
+									"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
+								},
+								{
+									"key": "access-control-expose-headers",
+									"value": "Retry-After",
+									"name": "access-control-expose-headers",
+									"description": "Lets a server whitelist headers that browsers are allowed to access."
+								},
+								{
+									"key": "cache-control",
+									"value": "private, no-cache, no-store, must-revalidate",
+									"name": "cache-control",
+									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+								},
+								{
+									"key": "content-length",
+									"value": "252",
+									"name": "content-length",
+									"description": "The length of the response body in octets (8-bit bytes)"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json; charset=utf-8",
+									"name": "content-type",
+									"description": "The mime type of this content"
+								},
+								{
+									"key": "date",
+									"value": "Tue, 28 Aug 2018 17:26:34 GMT",
+									"name": "date",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"key": "etag",
+									"value": "W/\"fc-LvHOyiaj5/VWWtdeQl6ib5dUJ/Y\"",
+									"name": "etag",
+									"description": "An identifier for a specific version of a resource, often a message digest"
+								},
+								{
+									"key": "expires",
+									"value": "-1",
+									"name": "expires",
+									"description": "Gives the date/time after which the response is considered stale"
+								},
+								{
+									"key": "pragma",
+									"value": "no-cache",
+									"name": "pragma",
+									"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
+								},
+								{
+									"key": "server",
+									"value": "nginx/1.13.8",
+									"name": "server",
+									"description": "A name for the server"
+								},
+								{
+									"key": "status",
+									"value": "200",
+									"name": "status",
+									"description": "Custom header"
+								},
+								{
+									"key": "strict-transport-security",
+									"value": "max-age=31536000",
+									"name": "strict-transport-security",
+									"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
+								},
+								{
+									"key": "vary",
+									"value": "Origin",
+									"name": "vary",
+									"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
+								},
+								{
+									"key": "x-content-type-options",
+									"value": "nosniff",
+									"name": "x-content-type-options",
+									"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
+								},
+								{
+									"key": "x-frame-options",
+									"value": "SAMEORIGIN",
+									"name": "x-frame-options",
+									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
+								},
+								{
+									"key": "x-xss-protection",
+									"value": "1; mode=block",
+									"name": "x-xss-protection",
+									"description": "Cross-site scripting (XSS) filter"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"menu\": {\n        \"items\": [\n            {\n                \"type\": \"link\",\n                \"text\": \"Smooch\",\n                \"uri\": \"http://smooch.io\",\n                \"_id\": \"57b331fbf1c6a1f940dc7\"\n            }\n        ]\n    }\n}"
 						}
 					]
 				},
@@ -13660,8 +13742,10 @@
 							],
 							"variable": [
 								{
+									"id": "a2884c6e-36ea-454e-92d1-ff1f2e9120d7",
 									"key": "integrationId",
-									"value": "{{integrationId}}"
+									"value": "{{integrationId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -14015,8 +14099,10 @@
 							],
 							"variable": [
 								{
+									"id": "fe564e66-bf0f-46fa-abd9-0127e39fff9a",
 									"key": "serviceAccountId",
-									"value": "{{serviceAccountId}}"
+									"value": "{{serviceAccountId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -14168,8 +14254,10 @@
 							],
 							"variable": [
 								{
+									"id": "cd5d8f9f-c887-44a7-9c85-506f0428deff",
 									"key": "serviceAccountId",
-									"value": "{{serviceAccountId}}"
+									"value": "{{serviceAccountId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -14207,8 +14295,10 @@
 							],
 							"variable": [
 								{
+									"id": "bc63f317-cea4-4ea7-ba2b-6679bbbd31f1",
 									"key": "serviceAccountId",
-									"value": "{{serviceAccountId}}"
+									"value": "{{serviceAccountId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -14395,8 +14485,10 @@
 							],
 							"variable": [
 								{
+									"id": "4ae61b1b-7fce-47ad-95ff-6fb550dd5cb4",
 									"key": "serviceAccountId",
-									"value": "{{serviceAccountId}}"
+									"value": "{{serviceAccountId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -14574,8 +14666,10 @@
 							],
 							"variable": [
 								{
+									"id": "9f56be36-4de3-439a-9a3a-6c0e3bd84ad9",
 									"key": "serviceAccountId",
-									"value": "{{serviceAccountId}}"
+									"value": "{{serviceAccountId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -14732,12 +14826,16 @@
 							],
 							"variable": [
 								{
+									"id": "adccdc6b-a353-4f21-9250-b3bc4ff58645",
 									"key": "serviceAccountId",
-									"value": "{{serviceAccountId}}"
+									"value": "{{serviceAccountId}}",
+									"type": "string"
 								},
 								{
+									"id": "f0d63387-1fc2-4d97-aec0-6709e680f905",
 									"key": "serviceKeyId",
-									"value": "{{serviceKeyId}}"
+									"value": "{{serviceKeyId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -14893,12 +14991,16 @@
 							],
 							"variable": [
 								{
+									"id": "0fa38416-d7c2-4b5f-bb41-8ac70ad71408",
 									"key": "serviceAccountId",
-									"value": "{{serviceAccountId}}"
+									"value": "{{serviceAccountId}}",
+									"type": "string"
 								},
 								{
+									"id": "a8814b4c-2e8b-41d3-a8d3-8163bf7c225d",
 									"key": "serviceKeyId",
-									"value": "{{serviceKeyId}}"
+									"value": "{{serviceKeyId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -14935,12 +15037,16 @@
 							],
 							"variable": [
 								{
+									"id": "47a4bdd7-0764-43d5-b207-dd4d2a321b02",
 									"key": "serviceAccountId",
-									"value": "{{serviceAccountId}}"
+									"value": "{{serviceAccountId}}",
+									"type": "string"
 								},
 								{
+									"id": "35ec4698-5c9e-4556-b608-46c18a44c69e",
 									"key": "serviceKeyId",
-									"value": "{{serviceKeyId}}"
+									"value": "{{serviceKeyId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -15445,156 +15551,6 @@
 							},
 							"response": [
 								{
-									"name": "Send Template - Request Location",
-									"originalRequest": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "Authorization",
-												"value": "Bearer {{JWT}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"role\": \"appMaker\",\n    \"type\": \"text\",\n    \"text\": \"%{{template: carousel_template}}%\"\n}"
-										},
-										"url": {
-											"raw": "{{url}}/v1/apps/{{appId}}/appusers/{{appUserId}}/messages",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"v1",
-												"apps",
-												"{{appId}}",
-												"appusers",
-												"{{appUserId}}",
-												"messages"
-											]
-										},
-										"description": "1. To send a template, first create a template. You can create a template with the examples provided.\n2. Replace the template name in the body. \n\n- API Docs: [https://docs.smooch.io/guide/template-messages/#sending-a-template-message](https://docs.smooch.io/guide/template-messages/#sending-a-template-message)\n\n- See the [capabilities grid](https://docs.smooch.io/guide/channel-capabilities/) for message-type support across channels."
-									},
-									"status": "Created",
-									"code": 201,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "access-control-allow-credentials",
-											"value": "true",
-											"name": "access-control-allow-credentials",
-											"description": "Indicates whether or not the response to the request can be exposed when the credentials flag is true. When used as part of a response to a preflight request, this indicates whether or not the actual request can be made using credentials."
-										},
-										{
-											"key": "access-control-allow-origin",
-											"value": "chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop",
-											"name": "access-control-allow-origin",
-											"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
-										},
-										{
-											"key": "access-control-expose-headers",
-											"value": "Retry-After",
-											"name": "access-control-expose-headers",
-											"description": "Lets a server whitelist headers that browsers are allowed to access."
-										},
-										{
-											"key": "cache-control",
-											"value": "private, no-cache, no-store, must-revalidate",
-											"name": "cache-control",
-											"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
-										},
-										{
-											"key": "content-length",
-											"value": "529",
-											"name": "content-length",
-											"description": "The length of the response body in octets (8-bit bytes)"
-										},
-										{
-											"key": "content-type",
-											"value": "application/json; charset=utf-8",
-											"name": "content-type",
-											"description": "The mime type of this content"
-										},
-										{
-											"key": "date",
-											"value": "Wed, 05 Sep 2018 21:23:18 GMT",
-											"name": "date",
-											"description": "The date and time that the message was sent"
-										},
-										{
-											"key": "etag",
-											"value": "W/\"211-DfWjjelh3o1QmiM9jg2XqLuFYo8\"",
-											"name": "etag",
-											"description": "An identifier for a specific version of a resource, often a message digest"
-										},
-										{
-											"key": "expires",
-											"value": "-1",
-											"name": "expires",
-											"description": "Gives the date/time after which the response is considered stale"
-										},
-										{
-											"key": "poll-interval",
-											"value": "30",
-											"name": "poll-interval",
-											"description": "Custom header"
-										},
-										{
-											"key": "pragma",
-											"value": "no-cache",
-											"name": "pragma",
-											"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
-										},
-										{
-											"key": "server",
-											"value": "nginx/1.13.8",
-											"name": "server",
-											"description": "A name for the server"
-										},
-										{
-											"key": "status",
-											"value": "201",
-											"name": "status",
-											"description": "Custom header"
-										},
-										{
-											"key": "strict-transport-security",
-											"value": "max-age=31536000",
-											"name": "strict-transport-security",
-											"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
-										},
-										{
-											"key": "vary",
-											"value": "X-HTTP-Method-Override, Origin",
-											"name": "vary",
-											"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
-										},
-										{
-											"key": "x-content-type-options",
-											"value": "nosniff",
-											"name": "x-content-type-options",
-											"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
-										},
-										{
-											"key": "x-frame-options",
-											"value": "SAMEORIGIN",
-											"name": "x-frame-options",
-											"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
-										},
-										{
-											"key": "x-xss-protection",
-											"value": "1; mode=block",
-											"name": "x-xss-protection",
-											"description": "Cross-site scripting (XSS) filter"
-										}
-									],
-									"cookie": [],
-									"body": "{\"message\":{\"text\":\"Let us know where you are.\",\"actions\":[{\"text\":\"Send location\",\"_id\":\"5b9049468c017000222b1efc\",\"uri\":\"\",\"type\":\"locationRequest\"}],\"type\":\"text\",\"role\":\"appMaker\",\"received\":1536182598.841,\"authorId\":\"00ufq983xhQAh5g8H0h7\",\"avatarUrl\":\"https://www.gravatar.com/avatar/00000000000000000000000000000000.png?s=200&d=mm\",\"_id\":\"5b9049468c017000222b1efb\",\"source\":{\"type\":\"api\"}},\"conversation\":{\"unreadCount\":1,\"_id\":\"c0021c2a74305c84313bc2ab\",\"appMakerLastRead\":1536182598.841,\"appUserLastRead\":1536182570.411}}"
-								},
-								{
 									"name": "Send Template - Compound",
 									"originalRequest": {
 										"method": "POST",
@@ -15893,6 +15849,156 @@
 									],
 									"cookie": [],
 									"body": "{\"message\":{\"text\":\"1. Scandinave Getaway\\nEnjoy massage treatments situated in a serene natural forest with an on-site bistro serving healthy local fare.\\n\\n\\n2. Brewery Tour\\nExplore Boston's thriving brewpub scene and taste roughly 18 types of beer on these guided morning and evening brewery tours.\\n\\n\\n3. Whale Watching\\nExperience the marine wildlife on this guided, 3-hour whale-watching cruise around the National Marine Sanctuary.\\n\\n\\n4. French Dining\\nGary Danko provides an award-winning combination of classic French cooking and personable yet impeccable service.\\n\\n\\n5. Seafood Cuisine\\nOstra focuses on specialty seafood and the cuisine highlights the natural and fresh flavors of each dish.\\n\",\"items\":[{\"mediaUrl\":\"https://media.smooch.io/templates/template-scandinave.jpg\",\"mediaType\":\"image/jpeg\",\"description\":\"Enjoy massage treatments situated in a serene natural forest with an on-site bistro serving healthy local fare.\",\"title\":\"Scandinave Getaway\",\"_id\":\"5b904987effe0700226ba45d\",\"actions\":[{\"payload\":\"NOOP\",\"text\":\"Learn more\",\"_id\":\"5b904987effe0700226ba45f\",\"uri\":\"\",\"type\":\"postback\"},{\"payload\":\"NOOP\",\"text\":\"Check availability\",\"_id\":\"5b904987effe0700226ba45e\",\"uri\":\"\",\"type\":\"postback\"}]},{\"mediaUrl\":\"https://media.smooch.io/templates/template-brewery-tour.jpg\",\"mediaType\":\"image/jpeg\",\"description\":\"Explore Boston's thriving brewpub scene and taste roughly 18 types of beer on these guided morning and evening brewery tours.\",\"title\":\"Brewery Tour\",\"_id\":\"5b904987effe0700226ba45a\",\"actions\":[{\"payload\":\"NOOP\",\"text\":\"Learn more\",\"_id\":\"5b904987effe0700226ba45c\",\"uri\":\"\",\"type\":\"postback\"},{\"payload\":\"NOOP\",\"text\":\"Check availability\",\"_id\":\"5b904987effe0700226ba45b\",\"uri\":\"\",\"type\":\"postback\"}]},{\"mediaUrl\":\"https://media.smooch.io/templates/template-whale-watching.jpg\",\"mediaType\":\"image/jpeg\",\"description\":\"Experience the marine wildlife on this guided, 3-hour whale-watching cruise around the National Marine Sanctuary.\",\"title\":\"Whale Watching\",\"_id\":\"5b904987effe0700226ba457\",\"actions\":[{\"payload\":\"NOOP\",\"text\":\"Learn more\",\"_id\":\"5b904987effe0700226ba459\",\"uri\":\"\",\"type\":\"postback\"},{\"payload\":\"NOOP\",\"text\":\"Check availability\",\"_id\":\"5b904987effe0700226ba458\",\"uri\":\"\",\"type\":\"postback\"}]},{\"mediaUrl\":\"https://media.smooch.io/templates/template-french-dining.jpg\",\"mediaType\":\"image/jpeg\",\"description\":\"Gary Danko provides an award-winning combination of classic French cooking and personable yet impeccable service.\",\"title\":\"French Dining\",\"_id\":\"5b904987effe0700226ba454\",\"actions\":[{\"payload\":\"NOOP\",\"text\":\"Learn more\",\"_id\":\"5b904987effe0700226ba456\",\"uri\":\"\",\"type\":\"postback\"},{\"payload\":\"NOOP\",\"text\":\"Check availability\",\"_id\":\"5b904987effe0700226ba455\",\"uri\":\"\",\"type\":\"postback\"}]},{\"mediaUrl\":\"https://media.smooch.io/templates/template-seafood-cuisine.jpg\",\"mediaType\":\"image/jpeg\",\"description\":\"Ostra focuses on specialty seafood and the cuisine highlights the natural and fresh flavors of each dish.\",\"title\":\"Seafood Cuisine\",\"_id\":\"5b904987effe0700226ba451\",\"actions\":[{\"payload\":\"NOOP\",\"text\":\"Learn more\",\"_id\":\"5b904987effe0700226ba453\",\"uri\":\"\",\"type\":\"postback\"},{\"payload\":\"NOOP\",\"text\":\"Check availability\",\"_id\":\"5b904987effe0700226ba452\",\"uri\":\"\",\"type\":\"postback\"}]}],\"type\":\"carousel\",\"role\":\"appMaker\",\"received\":1536182663.726,\"authorId\":\"00ufq983xhQAh5g8H0h7\",\"avatarUrl\":\"https://www.gravatar.com/avatar/00000000000000000000000000000000.png?s=200&d=mm\",\"_id\":\"5b904987effe0700226ba450\",\"source\":{\"type\":\"api\"}},\"conversation\":{\"unreadCount\":1,\"_id\":\"c0021c2a74305c84313bc2ab\",\"appMakerLastRead\":1536182663.726,\"appUserLastRead\":1536182642.419}}"
+								},
+								{
+									"name": "Send Template - Request Location",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{JWT}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"role\": \"appMaker\",\n    \"type\": \"text\",\n    \"text\": \"%{{template: carousel_template}}%\"\n}"
+										},
+										"url": {
+											"raw": "{{url}}/v1/apps/{{appId}}/appusers/{{appUserId}}/messages",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"v1",
+												"apps",
+												"{{appId}}",
+												"appusers",
+												"{{appUserId}}",
+												"messages"
+											]
+										},
+										"description": "1. To send a template, first create a template. You can create a template with the examples provided.\n2. Replace the template name in the body. \n\n- API Docs: [https://docs.smooch.io/guide/template-messages/#sending-a-template-message](https://docs.smooch.io/guide/template-messages/#sending-a-template-message)\n\n- See the [capabilities grid](https://docs.smooch.io/guide/channel-capabilities/) for message-type support across channels."
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "access-control-allow-credentials",
+											"value": "true",
+											"name": "access-control-allow-credentials",
+											"description": "Indicates whether or not the response to the request can be exposed when the credentials flag is true. When used as part of a response to a preflight request, this indicates whether or not the actual request can be made using credentials."
+										},
+										{
+											"key": "access-control-allow-origin",
+											"value": "chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop",
+											"name": "access-control-allow-origin",
+											"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
+										},
+										{
+											"key": "access-control-expose-headers",
+											"value": "Retry-After",
+											"name": "access-control-expose-headers",
+											"description": "Lets a server whitelist headers that browsers are allowed to access."
+										},
+										{
+											"key": "cache-control",
+											"value": "private, no-cache, no-store, must-revalidate",
+											"name": "cache-control",
+											"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+										},
+										{
+											"key": "content-length",
+											"value": "529",
+											"name": "content-length",
+											"description": "The length of the response body in octets (8-bit bytes)"
+										},
+										{
+											"key": "content-type",
+											"value": "application/json; charset=utf-8",
+											"name": "content-type",
+											"description": "The mime type of this content"
+										},
+										{
+											"key": "date",
+											"value": "Wed, 05 Sep 2018 21:23:18 GMT",
+											"name": "date",
+											"description": "The date and time that the message was sent"
+										},
+										{
+											"key": "etag",
+											"value": "W/\"211-DfWjjelh3o1QmiM9jg2XqLuFYo8\"",
+											"name": "etag",
+											"description": "An identifier for a specific version of a resource, often a message digest"
+										},
+										{
+											"key": "expires",
+											"value": "-1",
+											"name": "expires",
+											"description": "Gives the date/time after which the response is considered stale"
+										},
+										{
+											"key": "poll-interval",
+											"value": "30",
+											"name": "poll-interval",
+											"description": "Custom header"
+										},
+										{
+											"key": "pragma",
+											"value": "no-cache",
+											"name": "pragma",
+											"description": "Implementation-specific headers that may have various effects anywhere along the request-response chain."
+										},
+										{
+											"key": "server",
+											"value": "nginx/1.13.8",
+											"name": "server",
+											"description": "A name for the server"
+										},
+										{
+											"key": "status",
+											"value": "201",
+											"name": "status",
+											"description": "Custom header"
+										},
+										{
+											"key": "strict-transport-security",
+											"value": "max-age=31536000",
+											"name": "strict-transport-security",
+											"description": "A HSTS Policy informing the HTTP client how long to cache the HTTPS only policy and whether this applies to subdomains."
+										},
+										{
+											"key": "vary",
+											"value": "X-HTTP-Method-Override, Origin",
+											"name": "vary",
+											"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
+										},
+										{
+											"key": "x-content-type-options",
+											"value": "nosniff",
+											"name": "x-content-type-options",
+											"description": "The only defined value, \"nosniff\", prevents Internet Explorer from MIME-sniffing a response away from the declared content-type"
+										},
+										{
+											"key": "x-frame-options",
+											"value": "SAMEORIGIN",
+											"name": "x-frame-options",
+											"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
+										},
+										{
+											"key": "x-xss-protection",
+											"value": "1; mode=block",
+											"name": "x-xss-protection",
+											"description": "Cross-site scripting (XSS) filter"
+										}
+									],
+									"cookie": [],
+									"body": "{\"message\":{\"text\":\"Let us know where you are.\",\"actions\":[{\"text\":\"Send location\",\"_id\":\"5b9049468c017000222b1efc\",\"uri\":\"\",\"type\":\"locationRequest\"}],\"type\":\"text\",\"role\":\"appMaker\",\"received\":1536182598.841,\"authorId\":\"00ufq983xhQAh5g8H0h7\",\"avatarUrl\":\"https://www.gravatar.com/avatar/00000000000000000000000000000000.png?s=200&d=mm\",\"_id\":\"5b9049468c017000222b1efb\",\"source\":{\"type\":\"api\"}},\"conversation\":{\"unreadCount\":1,\"_id\":\"c0021c2a74305c84313bc2ab\",\"appMakerLastRead\":1536182598.841,\"appUserLastRead\":1536182570.411}}"
 								}
 							]
 						}
@@ -17319,8 +17425,10 @@
 							],
 							"variable": [
 								{
+									"id": "c1322474-4a5a-461d-b72e-fd63f270c74b",
 									"key": "templateId",
-									"value": "{{templateId}}"
+									"value": "{{templateId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -17475,8 +17583,10 @@
 							],
 							"variable": [
 								{
+									"id": "842b79c7-92ec-42a2-bb12-1b1fdb9ebe52",
 									"key": "templateId",
-									"value": "{{templateId}}"
+									"value": "{{templateId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -17636,8 +17746,10 @@
 							],
 							"variable": [
 								{
+									"id": "aca91927-f03b-4c12-9417-5f603fe6deee",
 									"key": "templateId",
-									"value": "{{templateId}}"
+									"value": "{{templateId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -18043,8 +18155,10 @@
 							],
 							"variable": [
 								{
+									"id": "260e1084-795c-46df-8652-e00542cab8d2",
 									"key": "webhookId",
-									"value": "{{webhookId}}"
+									"value": "{{webhookId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -18200,8 +18314,10 @@
 							],
 							"variable": [
 								{
+									"id": "86622c0e-447e-4380-a355-db714246b356",
 									"key": "webhookId",
-									"value": "{{webhookId}}"
+									"value": "{{webhookId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -18385,8 +18501,10 @@
 							],
 							"variable": [
 								{
+									"id": "0dc11d0c-3f11-4b23-802e-01383bb3379a",
 									"key": "webhookId",
-									"value": "{{webhookId}}"
+									"value": "{{webhookId}}",
+									"type": "string"
 								}
 							]
 						},
@@ -18545,7 +18663,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "ca07546b-f4f0-412d-9488-170db24bdbaa",
+						"id": "0eada563-bfac-4609-ac55-98b843424eb6",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -18555,7 +18673,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "7ab9c097-f239-4216-b4ce-aab872932d43",
+						"id": "74ca0ea2-c206-41a4-a92f-264a9758b649",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -18567,16 +18685,11 @@
 		}
 	],
 	"auth": {
-		"type": "basic",
-		"basic": [
+		"type": "bearer",
+		"bearer": [
 			{
-				"key": "password",
-				"value": "{{secret}}",
-				"type": "string"
-			},
-			{
-				"key": "username",
-				"value": "{{keyId}}",
+				"key": "token",
+				"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InN5c181ZTlmMTM4NTdlOGY2NDFiMDIwYTA4YWUifQ.eyJzY29wZSI6ImFwcCIsInplbmRlc2tBY2NvdW50SWQiOiJ6ZW5kZXNrQWNjb3VudElkMSIsImlhdCI6MTU5NDkwODcwOCwibmJmIjoxNTk0OTA4NzA4LCJleHAiOjE1OTQ5MTIzMDh9.bw7E57OULBC1Ktw0yAztvR6_ea3a8vvEAiSYEc-Agws",
 				"type": "string"
 			}
 		]
@@ -18585,7 +18698,7 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "473635b5-21aa-4ca4-8828-d390f2acd51f",
+				"id": "de0da506-855c-47bb-b421-27851a31d430",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -18595,7 +18708,7 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "b3c78d47-63d2-4f67-b5e0-5363b31c4d2e",
+				"id": "834f68c0-4c57-4905-a93f-b424b38a37bc",
 				"type": "text/javascript",
 				"exec": [
 					""


### PR DESCRIPTION
## Request for Change

[Description and reason for the change](https://zendesk.atlassian.net/jira/software/projects/SCC/boards/1780?selectedIssue=SCC-404)

Added 2 more apis to the smooch postman collection under attachments API folder [@here](https://github.com/zendesk/sunshine-conversations-postman-collection-public/pull/19/files#diff-4b081629b5ae173add1b20828fb6033bR2770-R3172)

- Generate Media Token
- Get Cookie

Priority : `low` <!-- low/medium/high/urgent -->
Impact : `low` <!-- low/medium/high -->
Risk : `low` <!-- low/medium/high -->
Classification : `preauthorized` <!-- preauthorized/minor/major/emergency -->
Security impact: None <!-- describe if there is a security impact to this change -->

Automated tests: N/A
Manual tests: N/A <!-- or link to bug bash card -->

Expected deployment date/time : DATE_TIME <!-- YYYY-MM-DD HH:MM AM/PM -->
Expected downtime duration : 0 minutes
Rollout plan & rollback instructions: Revert github files and push to master

<!-- Change management policy:  https://docs.google.com/document/d/15Zz9it49fZl8Q4oKL-tL8kXPbnUPfdIUCEdv_x5P4vU/edit#-->
